### PR TITLE
Fix issues to run in icehouse

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
@@ -166,7 +166,14 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
     #end __init__
 
     def _get_base_binding_dict(self):
-        binding = {
+        if hasattr(portbindings, 'VIF_DETAILS'):
+            binding = {
+            portbindings.VIF_TYPE: portbindings.VIF_TYPE_VROUTER,
+            portbindings.VIF_DETAILS: {
+                portbindings.CAP_PORT_FILTER:
+                'security-group' in self.supported_extension_aliases}}
+        else:
+            binding = {
             portbindings.VIF_TYPE: portbindings.VIF_TYPE_VROUTER,
             portbindings.CAPABILITIES: {
                 portbindings.CAP_PORT_FILTER:

--- a/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
@@ -1430,6 +1430,8 @@ class DBInterface(object):
         sn_q_dict['tenant_id'] = net_obj.parent_uuid.replace('-', '')
         sn_q_dict['network_id'] = net_obj.uuid
         sn_q_dict['ip_version'] = 4  # TODO ipv6?
+        sn_q_dict['ipv6_ra_mode'] = None
+        sn_q_dict['ipv6_address_mode'] = None
 
         cidr = '%s/%s' % (subnet_vnc.subnet.get_ip_prefix(),
                           subnet_vnc.subnet.get_ip_prefix_len())


### PR DESCRIPTION
This pull request fixes the changes required to run opencontrail plugin with neutron icehouse
Two changes are done
1. neutron icehouse has removed 'CAPABILITIES' and added 'VIF_DETAILS' in portbindings.py. Added the code to fix this
2. /opt/stack/neutron/neutron/db/db_base_plugin_v2.py in the function _make_subnet_dict, expects 'ipv6_ra_mode' and 'ipv6_address_mode' keys to be present in the 'subnet' dictionary. Added the code to fix this.
