### PR TITLE
Enable configuration of contrail extensions

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
@@ -36,7 +36,7 @@ vnc_opts = [
     cfg.StrOpt('api_server_ip', default='127.0.0.1'),
     cfg.StrOpt('api_server_port', default='8082'),
     cfg.BoolOpt('multi_tenancy', default=False),
-    cfg.StrOpt('contrail_extensions', default='',
+    cfg.StrOpt('contrail_extensions', default='ipam,policy,route-table',
                help='Contrail extensions support'),
 ]
 


### PR DESCRIPTION
This pull request provides the option to enable or disable opecontrail extensiosn - ipam, policy and route-table.

The code is taken from the https://github.com/Juniper/neutron/blob/contrail/havana-R1.06/neutron/plugins/juniper/contrail/contrail_plugin_core.py

Since there is no file for each of the extensions (contrail_plugin_ipam.py etc) in this repo yet, the 'contrail_extensions' in the ContrailPlugin.ini is of the below format 
contrail_extensions=ipam,policy,...
