### PR TITLE
Fix nova floating-ip-* command failures

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
@@ -2631,15 +2631,17 @@ class DBInterface(object):
 
         if port_ids:
             fip_objs = self._floatingip_list(back_ref_id=port_ids)
-            for fip_obj in fip_objs:
-                ret_list.append(self._floatingip_vnc_to_neutron(fip_obj))
         elif proj_ids:
             fip_objs = self._floatingip_list(back_ref_id=proj_ids)
-            for fip_obj in fip_objs:
-                ret_list.append(self._floatingip_vnc_to_neutron(fip_obj))
         else:
             fip_objs = self._floatingip_list()
-            for fip_obj in fip_objs:
+
+        for fip_obj in fip_objs:
+            if 'floating_ip_address' in filters:
+                if fip_obj.get_floating_ip_address() in \
+                    filters['floating_ip_address']:
+                    ret_list.append(self._floatingip_vnc_to_neutron(fip_obj))
+            else:
                 ret_list.append(self._floatingip_vnc_to_neutron(fip_obj))
 
         return ret_list
@@ -2814,8 +2816,12 @@ class DBInterface(object):
         all_project_ids = []
 
         # TODO used to find dhcp server field. support later...
-        if 'device_owner' in filters:
-            return ret_q_ports
+        # nova calls neutron.get_ports with 'device_owner' set in the filters
+        # for nova floating-ip-* commands.
+        # commenting the below check for now to support these commands
+        
+        #if 'device_owner' in filters:
+        #    return ret_q_ports
 
         if not 'device_id' in filters:
             # Listing from back references


### PR DESCRIPTION
This pull request fixes the failures in the 'nova floating-ip-create, nova floating-ip-associate, nova floating-ip-disassociate ..' commands.
Two fixes are required to support these commands
1. nova  calls neutron.get_ports with 'device_owner' set in the 'filters'. 
2. nova calls neutron.get_floatingips with 'floating_ip_address' set in filters. If 'floating_ip_address' is set, then 'floatingip_list' function should return only the list of floating ips with the specified floating_ip_address and not all the floating ips.
