### PR TITLE
Subnet todo

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/ctdb/config_db.py
@@ -1486,10 +1486,8 @@ class DBInterface(object):
                 nameserver_dict_list.append(nameserver_entry) 
             sn_q_dict['dns_nameservers'] = nameserver_dict_list
              
-        # TODO get from ipam_obj
-        sn_q_dict['routes'] = [{'destination': 'TODO-destination',
-                               'nexthop': 'TODO-nexthop',
-                               'subnet_id': sn_id}]
+        # TODO get from ipam_obj when host-routes is supported
+        sn_q_dict['routes'] = []
 
         if net_obj.is_shared:
             sn_q_dict['shared'] = True


### PR DESCRIPTION
This pull request does the following
1. Send proper error message if subnet is created with the attributes  '--no-gateway' and  '--host-routes'
2. Remove the TODO message for 'host-routes' attributes
