### PR TITLE
Properly Catch RefsExistError on ressource creation

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrailplugin.py
@@ -364,6 +364,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_subnet(): " + pformat(subnet_dict))
             return subnet_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='subnet', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -471,6 +473,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_ipam(): " + pformat(ipam_dict))
             return ipam_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='ipam', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -579,6 +583,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_policy(): " + pformat(policy_dict))
             return policy_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='policy', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -706,6 +712,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_router(): " + pformat(router_dict) + "\n")
             return router_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='router', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -863,6 +871,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_floatingip(): " + pformat(fip_dict))
             return fip_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='floatingip', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -965,6 +975,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_port(): " + pformat(port_dict))
             return port_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='port', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1123,6 +1135,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
             rt_dict.update(rt_info['q_extra_data'])
             LOG.debug("create_route_table(): " + pformat(rt_dict))
             return rt_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='route_table', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1217,6 +1231,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_nat_instance(): " + pformat(si_dict))
             return si_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='nat_instance', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1308,6 +1324,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_security_group(): " + pformat(sg_dict))
             return sg_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='security_group', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e
@@ -1397,6 +1415,8 @@ class ContrailPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             LOG.debug("create_security_group_rule(): " + pformat(sgr_dict))
             return sgr_dict
+        except RefsExistError as e:
+            raise exc.BadRequest(resource='security_group_rule', msg=str(e))
         except Exception as e:
             cgitb.Hook(format="text").handle(sys.exc_info())
             raise e


### PR DESCRIPTION
Create a resource with the same name with OpenContrail is not supported and raises a RefsExistError.
That patch catch that exception to raise a proper Neutron exception.
