### PR TITLE
Bug 1332794: Use the provided tenant id to get quotas instead of getting...

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/quota/driver.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/quota/driver.py
@@ -89,6 +89,7 @@ class QuotaDriver(object):
     def get_tenant_quotas(context, resources, tenant_id):
         try:
             proj_id = str(uuid.UUID(tenant_id))
+            cfgdb = ContrailPlugin._get_user_cfgdb(context)
             proj_obj = cfgdb._project_read(proj_id)
             quota = proj_obj.get_quota()
         except Exception as e:


### PR DESCRIPTION
... from context
