### PR TITLE
Update loadbalancer API representation

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/loadbalancer/v2/loadbalancer.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/loadbalancer/v2/loadbalancer.py
@@ -67,7 +67,7 @@ class LoadbalancerManager(ResourceManager):
         ll_back_refs = lb.get_loadbalancer_listener_back_refs()
         if ll_back_refs:
             for ll_back_ref in ll_back_refs:
-                ll_list.append(ll_back_ref['uuid'])
+                ll_list.append({"id": ll_back_ref['uuid']})
         return ll_list
 
     def _get_interface_params(self, lb, props):


### PR DESCRIPTION
Problem: Official LBaaSv2 API require "id": uuid syntax for listeners. gophercloud (which used by kubernetes) API fails on JSON unmarshmaling.