### PR TITLE
Only return policies from their own tenant, if not an admin.

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin_base.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin_base.py
@@ -74,6 +74,9 @@ vnc_opts = [
                help='keyfile to connect securely to  VNC controller'),
     cfg.StrOpt('cafile', default='',
                help='cafile to connect securely to VNC controller'),
+    cfg.BoolOpt('multi_tenancy',
+                default=False,
+                help='Enable multi tenancy'),
 ]
 
 analytics_opts = [

--- a/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin_policy.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin_policy.py
@@ -21,6 +21,11 @@ import logging
 from pprint import pformat
 import sys
 
+try:
+    from oslo.config import cfg
+except ImportError:
+    from oslo_config import cfg
+
 import cgitb
 
 LOG = logging.getLogger(__name__)
@@ -78,6 +83,9 @@ class NeutronPluginContrailPolicy(object):
         """
         Retrieves all policies identifiers.
         """
+        if not context.is_admin and cfg.CONF.APISERVER.multi_tenancy:
+           filters['tenant_id'] = context.project_id
+
         policy_dicts = self._core._list_resource('policy', context, filters,
                                                  fields)
 


### PR DESCRIPTION
multi_tenancy as an option was not even in the cfg, so added that. One part where it is beneficial, is in network policies, because you dont want to return all network policies if you are not an admin.